### PR TITLE
Change `README.md` so that it suggests `babel-cli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Clone, install dependencies, run.
 ```bash
 # Clone repository and install babel (globally)
 $ git clone https://github.com/istx25/2spooky4me
-$ npm install --global babel
+$ npm install --global babel-cli
 $ cd 2spooky4me/
 
 # Install the dependencies from our package.json


### PR DESCRIPTION
Apparently `babel` is now only the library and it does not install any binaries; `babel-node` seems to be part of `babel-cli` now.